### PR TITLE
Fix documentation grammar, punctuation, and consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ To deploy as a permanent systemd kiosk service on a Raspberry Pi 5 (8GB):
 ```bash
 ./deploy-pi.sh
 ```
-This automated script installs Debian audio/venv packages, sets up the Python environment, builds production UI assets, downloads the LiteRT model, registers the systemd unit from `deploy/gemma-translator.service`, and configures LXDE GUI autostart (`~/.config/lxsession/rpd-x/autostart`) to launch Chromium in kiosk mode pointing to `http://localhost:3000`.
+This automated script installs Debian audio/venv packages, sets up the Python environment, builds production UI assets, downloads the LiteRT-LM model, registers the systemd unit from `deploy/gemma-translator.service`, and configures LXDE GUI autostart (`~/.config/lxsession/rpd-x/autostart`) to launch Chromium in kiosk mode pointing to `http://localhost:3000`.
 
 ## Project Structure
 
@@ -80,7 +80,7 @@ This automated script installs Debian audio/venv packages, sets up the Python en
 - `deploy/` - Parameterizable systemd service unit template (`gemma-translator.service`).
 - `stl/` - STL files for 3D printing the hardware case.
 - `setup.sh` - Automates Python virtual environment creation and dependency installation.
-- `download_model.sh` - Fetches the required LiteRT model.
+- `download_model.sh` - Fetches the required LiteRT-LM model.
 - `start.sh` - Multi-process launcher supporting `--prod` and development modes.
 - `deploy-pi.sh` - One-command Raspberry Pi automated deployment script.
 
@@ -137,7 +137,8 @@ Open **Settings (⚙)** → **Keyboard Mode** → choose **Landscape** or **Vert
 | `landscape` | Active-person scheme (Space / Z / ← →) — default |
 | `vertical` | Two-hand scheme (Z / X / ← → / − +) |
 
-### Credits
+## Credits
+
 Made by a small team at [Google Creative Lab](https://github.com/googlecreativelab):
 - [Alan Yam](https://github.com/alanvww)
 - [Shashwath Santosh](https://x.com/shashwth)

--- a/deploy-pi.sh
+++ b/deploy-pi.sh
@@ -65,7 +65,7 @@ echo "[3/7] Installing frontend dependencies & building production UI..."
 npm --prefix "${PROJECT_DIR}/frontend" install
 npm --prefix "${PROJECT_DIR}/frontend" run build
 
-echo "[4/7] Downloading LiteRT model..."
+echo "[4/7] Downloading LiteRT-LM model..."
 "${PROJECT_DIR}/download_model.sh"
 
 echo "[5/7] Registering systemd service..."

--- a/frontend/src/components/ResponseDrawer.jsx
+++ b/frontend/src/components/ResponseDrawer.jsx
@@ -45,7 +45,7 @@ export default function ResponseDrawer({
       <div className="chat-panel">
         {!hasData ? (
           <div className="initial-placeholder">
-            {placeholderText || "Select languages, push to talk"}
+            {placeholderText || "Select languages, then push to talk."}
           </div>
         ) : (
           <>

--- a/frontend/src/components/SettingsOverlay.jsx
+++ b/frontend/src/components/SettingsOverlay.jsx
@@ -162,7 +162,7 @@ export default function SettingsOverlay({
           <label>API Key</label>
           <input
             type="password"
-            placeholder="Optional api key"
+            placeholder="Optional API key"
             value={config.apiKey}
             onChange={(e) => handleChange("apiKey", e.target.value)}
           />


### PR DESCRIPTION
- Promote Credits to a top-level README section (was nested under Keyboard Shortcuts)
- Use consistent LiteRT-LM naming in README and deploy-pi.sh
- Capitalize API in the settings placeholder text
- Improve the response drawer placeholder copy